### PR TITLE
Add Zapp configuration for GitHub imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,23 @@ A professional Flutter monorepo for SapuJagad, containing three main modules:
    - `cd tasker_app ; flutter pub get`
    - `cd admin_dashboard ; flutter pub get` (and enable web: `flutter config --enable-web` if needed)
 
-## Run
-- User App: `cd user_app ; flutter run`
-- Tasker App: `cd tasker_app ; flutter run`
-- Admin Dashboard (web): `cd admin_dashboard ; flutter run -d chrome`
+## Run & Preview the Apps
+
+You can launch each experience locally to inspect the UI and behaviour:
+
+1. Make sure you have at least one Flutter device available (`flutter devices`).
+   - For mobile, start an Android emulator or connect a physical device with USB debugging enabled.
+   - For the web dashboard, ensure `flutter config --enable-web` has been executed once, and Chrome is installed.
+2. From the repo root, run the desired target:
+   - **User App (mobile)**: `cd user_app && flutter run`
+   - **Tasker App (mobile)**: `cd tasker_app && flutter run`
+   - **Admin Dashboard (web)**: `cd admin_dashboard && flutter run -d chrome`
+
+Flutter hot-reload/hot-restart works as usual, so changes to the Dart code will be reflected immediately while the command is running.
+
+### Importing the Monorepo on Zapp
+
+Zapp expects a single Flutter project at the repository root. Because this workspace is a Melos monorepo, the included `zapp.yaml` file lists each app directory. When you import the repository into Zapp you can pick the `user_app`, `tasker_app`, or `admin_dashboard` targets from the project selector without extra configuration.
 
 ## Testing
 - Run tests per module, e.g. `cd shared_services ; dart test` or `cd user_app ; flutter test`.

--- a/user_app/pubspec.yaml
+++ b/user_app/pubspec.yaml
@@ -1,5 +1,5 @@
 name: user_app
-description: SapuJagad: Pesan & Bersih (User App)
+description: 'SapuJagad: Pesan & Bersih (User App)'
 publish_to: 'none'
 version: 0.1.0+1
 environment:

--- a/zapp.yaml
+++ b/zapp.yaml
@@ -1,0 +1,14 @@
+version: 1
+# Explicitly list every Flutter project so Zapp can import the monorepo.
+projects:
+  user_app:
+    projectPath: user_app
+    description: SapuJagad consumer experience
+  tasker_app:
+    projectPath: tasker_app
+    description: Tasker operations app
+  admin_dashboard:
+    projectPath: admin_dashboard
+    description: Web dashboard for administrators
+# Pick the mobile user app when the repo is imported without further input.
+defaultProject: user_app


### PR DESCRIPTION
## Summary
- add a zapp.yaml file that enumerates each Flutter app so GitHub imports succeed on Zapp
- document the new configuration and explain how to pick the desired project when importing the repo

## Testing
- not run (configuration and documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e4e2ae6fec83308a1da447b278b16c